### PR TITLE
Learn 587

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:edge
+
+RUN apk update && apk add git yq
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Trybe Blocked Files Checkout Action
 
-Github Action que restaura uma lista de arquivos da branch principal do repositório do projeto. Estes arquivos não podem ser alterados pelo estudante e são definidos no arquivo `trybe.yml` com a chave `ignore_files`.
+Github Action que restaura uma lista de arquivos da branch principal do repositório do projeto. Estes arquivos não podem ser alterados pela pessoa estudante e são definidos no arquivo `trybe.yml` com a chave `ignore_files`.
 
 Para chamar esta action é necessário adicionar um *step* no arquivo `.github/workflows/main.yml` do repositório do projeto.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
 
 ### Ignore files
 
-Para definir quais arquivos devem ser restaurados para desfazer as alteracões do estudante é necessário adicionar o diretório ou o caminho do arquivo no `trybe.yml` conforme exemplo abaixo:
+Para definir quais arquivos devem ser restaurados para desfazer as alteracões da pessoa estudante é necessário adicionar o diretório ou o caminho do arquivo no `trybe.yml` conforme exemplo abaixo:
 
 ```yaml
 ignore_files:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
 
 ### Inputs
 
-#### `restore_branch` **(obrigaório)**
+#### `restore_branch` **(obrigatório)**
 
 **Branch** do repositório do projeto para qual os arquivos serão restaurados. O valor **default** é `main`.
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
 # Trybe Blocked Files Checkout Action
+
+Github Action que restaura uma lista de arquivos da branch principal do repositório do projeto. Estes arquivos não podem ser alterados pelo estudante e são definidos no arquivo `trybe.yml` com a chave `ignore_files`.
+
+Para chamar esta action é necessário adicionar um *step* no arquivo `.github/workflows/main.yml` do repositório do projeto.
+
+Para verificar a última versão estável desta *action* [acesse aqui](https://github.com/betrybe/blocked-files-checkout-action/releases).
+
+Exemplo:
+```yaml
+jobs:
+  evaluator_job:
+    runs-on: ubuntu-18.04
+    name: Evaluator job
+    steps:
+      - uses: actions/checkout@v2
+      - name: 'Checkout protected files'
+        uses: betrybe/blocked-files-checkout-action@v1
+        with:
+          restore_branch: 'main'
+      - name: Jest evaluator step
+        id: test
+        uses: betrybe/jest-evaluator-action@v5
+      - name: Store evaluation step
+        uses: betrybe/store-evaluation-action@v2
+```
+
+### Inputs
+
+#### `restore_branch` **(obrigaório)**
+
+**Branch** do repositório do projeto para qual os arquivos serão restaurados. O valor **default** é `main`.
+
+### Ignore files
+
+Para definir quais arquivos devem ser restaurados para desfazer as alteracões do estudante é necessário adicionar o diretório ou o caminho do arquivo no `trybe.yml` conforme exemplo abaixo:
+
+```yaml
+ignore_files:
+  - test-dir
+  - .editorconfig
+  - .eslintrc
+  - api/config/main.json
+```

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,10 @@
+name: 'Checkout files'
+description: "Checkout a list of specified files from the repository's main branch"
+inputs:
+  restore_branch:
+    description: 'GitHub repository branch to restore files'
+    default: 'main'
+    required: true
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,5 +11,5 @@ fi
 files=$(yq r trybe.yml 'ignore_files(.==*)')
 
 for file in $files; do
-  git restore --source origin/master -- "$file"
+  git restore --source "origin/$INPUT_RESTORE_BRANCH" -- "$file"
 done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -l
+set -x
+
+git pull origin "$INPUT_RESTORE_BRANCH" --ff-only --allow-unrelated-histories
+
+files=$(yq r .trybe/config.yml 'ignore_files(.==*)')
+
+for file in $files; do
+  git restore --source origin/master -- "$file"
+done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,14 @@
 #!/bin/sh -l
 set -x
 
-git pull origin "$INPUT_RESTORE_BRANCH" --ff-only --allow-unrelated-histories
+git fetch origin "$INPUT_RESTORE_BRANCH"
 
-files=$(yq r .trybe/config.yml 'ignore_files(.==*)')
+if [ $? != 0 ]; then
+  printf "Execution error $?"
+  exit 1
+fi
+
+files=$(yq r trybe.yml 'ignore_files(.==*)')
 
 for file in $files; do
   git restore --source origin/master -- "$file"


### PR DESCRIPTION
[LEARN-587](https://trybe.atlassian.net/browse/LEARN-587?atlOrigin=eyJpIjoiMjFlNjlkMzQzNjViNDUwZTlkNjk3YmU0MGM0OTVkZDciLCJwIjoiaiJ9)


### Descrição

**Por que?**

Com essa funcionalidade não será necessário a utilização de um repositório de testes, reduzindo a quantidade de erros no desenvolvimento e na execução dos projetos.

**Como?**

Implementando uma GitHub Action que realiza o checkout de arquivos específicos garante que podemos substituir a forma atual.

**Critérios de avaliação**

- GitHub Action que realiza o checkout de arquivos específicos
- A GitHub Action deve receber a branch a ser restaurada como um parâmetro, o valor padrão deve ser "main"
- A GitHub Action deve receber a lista de arquivos e diretórios a serem restaurados a partir de um arquivo de configuração com o nome `.trybe.yml`

O formato do arquivo `.trybe.yml` deve ser:

```yaml
ignore_files:
  - .eslintrc.json
  - tests
  - .stylelintrc.json
```


O arquivo de configuração deve possui a chave `ignore_files` com a lista de arquivos e diretórios que devem ser restaurados