### PR TITLE
imp: modifica action para rodar com composite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM alpine:edge
-
-RUN apk update && apk add git yq
-
-COPY entrypoint.sh /entrypoint.sh
-
-ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -6,5 +6,10 @@ inputs:
     default: 'main'
     required: true
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: 'composite'
+  steps:
+    - id: job
+      shell: bash
+      run: ${{ github.action_path }}/restore.sh
+      env:
+        INPUT_RESTORE_BRANCH: ${{ inputs.restore_branch }}

--- a/restore.sh
+++ b/restore.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -l
-set -x
+set -e
+
+echo "Restore branch: '$INPUT_RESTORE_BRANCH'"
 
 git fetch origin "$INPUT_RESTORE_BRANCH"
 
@@ -11,5 +13,6 @@ fi
 files=$(yq e '.ignore_files[]' trybe.yml)
 
 for file in $files; do
+  echo "Restoring file '$file'..."
   git restore --source "origin/$INPUT_RESTORE_BRANCH" -- "$file"
 done


### PR DESCRIPTION
Conforme [thread](https://betrybe.slack.com/archives/C01Q3PY8LLW/p1638549528400200) foi identificado que alguns projetos passam mais tempo em build por estarem fazendo build do docker toda vez que o avaliador roda.

Esta PR faz o modifica a action para rodar via shell, usando composite ao invés de docker, assim removemos o tempo de build do avaliador