### PR TITLE
Restaura as pastas `.github/` e `.trybe/`

### DIFF
--- a/restore.sh
+++ b/restore.sh
@@ -11,6 +11,7 @@ if [ $? != 0 ]; then
 fi
 
 files=$(yq e '.ignore_files[]' trybe.yml)
+files=${files:+$files }".github/ .trybe/"
 
 for file in $files; do
   echo "Restoring file '$file'..."


### PR DESCRIPTION
Estamos desvinculando os avaliadores da API Gateway `github-actions-self-hosted` para utilizar os recursos próprios do Github ao disparar as actions. Um dos papéis do `gitHub-actions-self-hosted` é evitar que a pessoa estudante faça alterações nos arquivos das pastas `.github/` e `/.trybe`.

Para que alterações feitas pela pessoa estudante nestas pastas continuem não tendo efeito, foi ajustado a action para restaurar essas pastas da branch `master` antes de rodar o avaliador.